### PR TITLE
Gw null_ptr mtid crash

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -714,11 +714,11 @@ namespace Parse {
                         break;
                     case RNAME:
                         char_ptr = sam_hdr_tid2name(hdr, aln.delegate->core.tid);
-                        str_val = char_ptr;
+                        str_val = char_ptr ? char_ptr : "*";
                         break;
                     case RNEXT:
                         char_ptr = sam_hdr_tid2name(hdr, aln.delegate->core.mtid);
-                        str_val = char_ptr;
+                        str_val = char_ptr ? char_ptr : "*";
                         break;
                     case TID:
                         int_val = aln.delegate->core.tid;


### PR DESCRIPTION
# Summary
- I found gw crashing in a specific case where I was trying to filter by rnext (eg filter rnext == chr19).
- This appears to be due to the Parser::eval function passing a null_ptr (as mtid) and causing a crash
- This was fixed by getting the eval function to return a "*" when a read does not have a mate

## A bit more detail
'filter rnext == chr19'. Searching around for why this case, an ai helper suggested that it was due to sam_hdr_tid2name(hdr, mtid) returning a null_ptr when the mate was unmapped (ie mtid == -1). This null_ptr is then being passed on by the Parser::eval function. A small change to the parser eval function so that it returns a "*" (which is the SAM convention) if the mate is unmapped prevents this error.