### PR TITLE
Ability to add multiple markers to a region

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,8 +7,8 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  pull_request:
   push:
+    branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.gw.ini
+++ b/.gw.ini
@@ -43,6 +43,7 @@ sv_arcs=true
 mods=false
 mods_qual_threshold=150
 session_file=/Users/sbi8kc2/CLionProjects/gw/.gw_session.ini
+track_label_parser_rules = auto
 
 [view_thresholds]
 soft_clip=20000

--- a/.gw.ini
+++ b/.gw.ini
@@ -43,7 +43,6 @@ sv_arcs=true
 mods=false
 mods_qual_threshold=150
 session_file=/Users/sbi8kc2/CLionProjects/gw/.gw_session.ini
-track_label_parser_rules = auto
 
 [view_thresholds]
 soft_clip=20000

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -280,15 +280,43 @@ namespace Drawing {
                     path.lineTo(markerP, rp);
                     canvas->drawPath(path, theme.fcMarkers);
                 }
-                float markerP2 = (cl.xScaling * (float) (cl.region->markerPosEnd - cl.region->start)) + cl.xOffset;
-                if (markerP2 > cl.xOffset && markerP2 < (cl.regionPixels + cl.xOffset)) {
+                if (cl.region->markerPosEnd > cl.region->markerPos + 1) {
+                    float markerP2 = (cl.xScaling * (float) (cl.region->markerPosEnd - cl.region->start)) + cl.xOffset;
+                    if (markerP2 > cl.xOffset && markerP2 < (cl.regionPixels + cl.xOffset)) {
+                        path.reset();
+                        path.moveTo(markerP2, rp);
+                        path.lineTo(markerP2 - xp, rp);
+                        path.lineTo(markerP2, rp + (fonts.overlayHeight));
+                        path.lineTo(markerP2 + xp, rp);
+                        path.lineTo(markerP2, rp);
+                        canvas->drawPath(path, theme.fcMarkers);
+                    }
+                }
+            }
+            for (const auto& mp : cl.region->extraMarkers) {
+                float rp = refSpace + (cl.bamIdx * cl.yPixels);
+                float xp = fonts.overlayHeight * 0.5;
+                float markerP = (cl.xScaling * (float)(mp.first - cl.region->start)) + cl.xOffset;
+                if (markerP > cl.xOffset && markerP < cl.regionPixels - cl.xOffset) {
                     path.reset();
-                    path.moveTo(markerP2, rp);
-                    path.lineTo(markerP2 - xp, rp);
-                    path.lineTo(markerP2, rp + (fonts.overlayHeight));
-                    path.lineTo(markerP2 + xp, rp);
-                    path.lineTo(markerP2, rp);
+                    path.moveTo(markerP, rp);
+                    path.lineTo(markerP - xp, rp);
+                    path.lineTo(markerP, rp + (fonts.overlayHeight));
+                    path.lineTo(markerP + xp, rp);
+                    path.lineTo(markerP, rp);
                     canvas->drawPath(path, theme.fcMarkers);
+                }
+                if (mp.second > mp.first + 1) {
+                    float markerP2 = (cl.xScaling * (float)(mp.second - cl.region->start)) + cl.xOffset;
+                    if (markerP2 > cl.xOffset && markerP2 < (cl.regionPixels + cl.xOffset)) {
+                        path.reset();
+                        path.moveTo(markerP2, rp);
+                        path.lineTo(markerP2 - xp, rp);
+                        path.lineTo(markerP2, rp + (fonts.overlayHeight));
+                        path.lineTo(markerP2 + xp, rp);
+                        path.lineTo(markerP2, rp);
+                        canvas->drawPath(path, theme.fcMarkers);
+                    }
                 }
             }
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -265,35 +265,7 @@ namespace Drawing {
                 }
             }
 
-            if (cl.region->markerPos != -1) {
-                float rp;
-
-                rp = refSpace + (cl.bamIdx * cl.yPixels);
-                float xp = fonts.overlayHeight * 0.5;
-                float markerP = (cl.xScaling * (float) (cl.region->markerPos - cl.region->start)) + cl.xOffset;
-                if (markerP > cl.xOffset && markerP < cl.regionPixels - cl.xOffset) {
-                    path.reset();
-                    path.moveTo(markerP, rp);
-                    path.lineTo(markerP - xp, rp);
-                    path.lineTo(markerP, rp + (fonts.overlayHeight));
-                    path.lineTo(markerP + xp, rp);
-                    path.lineTo(markerP, rp);
-                    canvas->drawPath(path, theme.fcMarkers);
-                }
-                if (cl.region->markerPosEnd > cl.region->markerPos + 1) {
-                    float markerP2 = (cl.xScaling * (float) (cl.region->markerPosEnd - cl.region->start)) + cl.xOffset;
-                    if (markerP2 > cl.xOffset && markerP2 < (cl.regionPixels + cl.xOffset)) {
-                        path.reset();
-                        path.moveTo(markerP2, rp);
-                        path.lineTo(markerP2 - xp, rp);
-                        path.lineTo(markerP2, rp + (fonts.overlayHeight));
-                        path.lineTo(markerP2 + xp, rp);
-                        path.lineTo(markerP2, rp);
-                        canvas->drawPath(path, theme.fcMarkers);
-                    }
-                }
-            }
-            for (const auto& mp : cl.region->extraMarkers) {
+            for (const auto& mp : cl.region->markers) {
                 float rp = refSpace + (cl.bamIdx * cl.yPixels);
                 float xp = fonts.overlayHeight * 0.5;
                 float markerP = (cl.xScaling * (float)(mp.first - cl.region->start)) + cl.xOffset;

--- a/src/hts_funcs.cpp
+++ b/src/hts_funcs.cpp
@@ -2370,8 +2370,7 @@ namespace HGW {
                     region.chrom = parts[0];
                     region.start = std::stoi(parts[1]);
                     region.end = std::stoi(parts[2]);
-                    region.markerPos = region.start;
-                    region.markerPosEnd = region.end;
+                    region.markers = {{region.start, region.end}};
                     return true;
                 }
             }
@@ -2388,8 +2387,7 @@ namespace HGW {
                     region.chrom = bcf_hdr_id2name(hdr2, v2->rid);
                     region.start = (int)v2->pos;
                     region.end = region.start + v2->rlen;
-                    region.markerPos = region.start;
-                    region.markerPosEnd = region.end;
+                    region.markers = {{region.start, region.end}};
                     return true;
                 }
             }
@@ -2402,8 +2400,7 @@ namespace HGW {
                         region.chrom = b.chrom;
                         region.start = b.start;
                         region.end = b.end;
-                        region.markerPos = b.start;
-                        region.markerPosEnd = b.end;
+                        region.markers = {{b.start, b.end}};
                         return true;
                     }
                 }
@@ -2707,7 +2704,7 @@ namespace HGW {
             const auto &regions = multiRegions[i];
             const auto &lbl = multiLabels[i];
             std::string chrom2 = regions.size() > 1 ? regions[1].chrom : lbl.chrom;
-            long stop = regions.size() > 1 ? regions[1].markerPos : (regions.empty() ? lbl.pos : regions[0].markerPosEnd);
+            long stop = regions.size() > 1 ? regions[1].markers[0].first : (regions.empty() ? lbl.pos : regions[0].markers[0].second);
             seen.insert(makeVariantSearchKey(lbl.chrom, lbl.pos, chrom2, stop, lbl.variantId));
         }
 
@@ -2792,22 +2789,19 @@ namespace HGW {
             r1->chrom = chrom;
             r1->start = (1 > start - m_opts->pad) ? 1 : start - m_opts->pad;
             r1->end = stop + m_opts->pad;
-            r1->markerPos = start;
-            r1->markerPosEnd = stop;
+            r1->markers = {{start, stop}};
         } else {
             v.resize(2);
             r1 = &v[0];
             r1->chrom = chrom;
             r1->start = (1 > start - m_opts->pad) ? 1 : start - m_opts->pad;
             r1->end = start + m_opts->pad;
-            r1->markerPos = start;
-            r1->markerPosEnd = start;
+            r1->markers = {{start, start}};
             r2 = &v[1];
             r2->chrom = chrom2;
             r2->start = (1 > stop - m_opts->pad) ? 1 : stop - m_opts->pad;
             r2->end = stop + m_opts->pad;
-            r2->markerPos = stop;
-            r2->markerPosEnd = stop;
+            r2->markers = {{stop, stop}};
         }
         multiRegions.push_back(v);
         if (inputLabels->contains(rid)) {

--- a/src/plot_commands.cpp
+++ b/src/plot_commands.cpp
@@ -408,7 +408,12 @@ namespace Commands {
         }
         for (auto& rgn : p->regions) {
             if (rgn.chrom == chrom) {
-                rgn.extraMarkers.push_back({pos, end});
+                rgn.markers.push_back({pos, end});
+            }
+        }
+        if (p->frameId >= 0) {
+            for (auto& cl : p->collections) {
+                cl.resetDrawState();
             }
         }
         p->redraw = true;
@@ -417,9 +422,12 @@ namespace Commands {
 
     Err clear_markers_command(Plot* p) {
         for (auto& rgn : p->regions) {
-            rgn.markerPos    = -1;
-            rgn.markerPosEnd = -1;
-            rgn.extraMarkers.clear();
+            rgn.markers.clear();
+        }
+        if (p->frameId >= 0) {
+            for (auto& cl : p->collections) {
+                cl.resetDrawState();
+            }
         }
         p->redraw = true;
         return Err::NONE;
@@ -818,8 +826,7 @@ namespace Commands {
                 } else {
                     if (index < (int)p->regions.size()) {
                         if (p->regions[index].chrom == rgn.chrom) {
-                            rgn.markerPos = p->regions[index].markerPos;
-                            rgn.markerPosEnd = p->regions[index].markerPosEnd;
+                            rgn.markers = p->regions[index].markers;
                         }
                         p->regions[index] = rgn;
                         p->fetchRefSeq(p->regions[index]);
@@ -1532,8 +1539,7 @@ namespace Commands {
             } else {
                 Utils::Region &old = p->regions[p->regionSelection];
                 if (old.chrom == rgn.chrom) {
-                    rgn.markerPos = old.markerPos;
-                    rgn.markerPosEnd = old.markerPosEnd;
+                    rgn.markers = old.markers;
                     rgn.sortOption = old.sortOption;
                     rgn.sortPos = old.sortPos;
                     rgn.refBaseAtPos = old.refBaseAtPos;

--- a/src/plot_commands.cpp
+++ b/src/plot_commands.cpp
@@ -378,6 +378,53 @@ namespace Commands {
         return Err::NONE;
     }
 
+    Err add_marker_command(Plot* p, std::vector<std::string>& parts, std::ostream& out) {
+        if (parts.size() < 2) {
+            out << "Usage: marker <chrom:start-end>  or  marker <chrom> <pos> [end]\n";
+            return Err::OPTION_NOT_UNDERSTOOD;
+        }
+        std::string chrom;
+        int pos, end;
+        if (parts.size() == 2) {
+            // Accept region string format: chr1:15000-20000
+            try {
+                Utils::Region rgn = Utils::parseRegion(parts[1]);
+                chrom = rgn.chrom;
+                pos   = rgn.start;
+                end   = rgn.end;
+            } catch (...) {
+                out << "marker: could not parse '" << parts[1] << "' as a region\n";
+                return Err::OPTION_NOT_SUPPORTED;
+            }
+        } else {
+            chrom = parts[1];
+            try {
+                pos = std::stoi(parts[2]);
+                end = (parts.size() >= 4) ? std::stoi(parts[3]) : pos + 1;
+            } catch (...) {
+                out << "marker: invalid position\n";
+                return Err::OPTION_NOT_SUPPORTED;
+            }
+        }
+        for (auto& rgn : p->regions) {
+            if (rgn.chrom == chrom) {
+                rgn.extraMarkers.push_back({pos, end});
+            }
+        }
+        p->redraw = true;
+        return Err::NONE;
+    }
+
+    Err clear_markers_command(Plot* p) {
+        for (auto& rgn : p->regions) {
+            rgn.markerPos    = -1;
+            rgn.markerPosEnd = -1;
+            rgn.extraMarkers.clear();
+        }
+        p->redraw = true;
+        return Err::NONE;
+    }
+
     Err link(Plot* p, std::string& command, std::vector<std::string>& parts) {
         bool relink = false;
         if (command == "link" || command == "link all") {
@@ -1916,7 +1963,8 @@ namespace Commands {
                 {"tlen-y",   PARAMS { return tlen_y(p); }},
                 {"alignments",   PARAMS { return alignments(p); }},
                 {"labels",   PARAMS { return labels(p); }},
-
+                {"marker",        PARAMS { return add_marker_command(p, parts, out); }},
+                {"clear-markers", PARAMS { return clear_markers_command(p); }},
                 {"sam",      PARAMS { return sam(p, command, parts, out); }},
                 {"h",        PARAMS { return getHelp(p, command, parts, out); }},
                 {"help",     PARAMS { return getHelp(p, command, parts, out); }},

--- a/src/plot_manager.cpp
+++ b/src/plot_manager.cpp
@@ -800,8 +800,7 @@ namespace Manager {
             regions[0].chrom = chrom;
             regions[0].start = (1 > start - opts.pad) ? 1 : start - opts.pad;
             regions[0].end = stop + opts.pad;
-            regions[0].markerPos = start;
-            regions[0].markerPosEnd = stop;
+            regions[0].markers = {{start, stop}};
             if (opts.tlen_yscale) {
                 opts.max_tlen = stop - start;
             }
@@ -810,13 +809,11 @@ namespace Manager {
             regions[0].chrom = chrom;
             regions[0].start = (1 > start - opts.pad) ? 1 : start - opts.pad;
             regions[0].end = start + opts.pad;
-            regions[0].markerPos = start;
-            regions[0].markerPosEnd = start;
+            regions[0].markers = {{start, start}};
             regions[1].chrom = chrom2;
             regions[1].start = (1 > stop - opts.pad) ? 1 : stop - opts.pad;
             regions[1].end = stop + opts.pad;
-            regions[1].markerPos = stop;
-            regions[1].markerPosEnd = stop;
+            regions[1].markers = {{stop, stop}};
             if (opts.tlen_yscale) {
                 opts.max_tlen = 1500;
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -237,7 +237,7 @@ namespace Utils {
 
     std::string Region::toString() {
         return chrom + ":" + std::to_string(start) + "-" + std::to_string(end)
-           + ((markerPos >= 0) ? ":" + std::to_string(markerPos) + ":" + std::to_string(markerPosEnd) : "");
+           + (!markers.empty() ? ":" + std::to_string(markers[0].first) + ":" + std::to_string(markers[0].second) : "");
     }
 
     std::filesystem::path makeFilenameFromRegions(std::vector<Utils::Region> &regions) {
@@ -284,20 +284,17 @@ namespace Utils {
                     regions[0].chrom = parts[0];
                     regions[0].start = (start - pad > 0) ? start - pad : 1;
                     regions[0].end = start + pad;
-                    regions[0].markerPos = start;
-                    regions[0].markerPosEnd = end;
+                    regions[0].markers = {{start, end}};
                     regions[1].chrom = parts[2];
                     regions[1].start = (end - pad > 0) ? end - pad : 1;
                     regions[1].end = end + pad;
-                    regions[1].markerPos = end;
-                    regions[1].markerPosEnd = start;
+                    regions[1].markers = {{end, start}};
                 } else {
                     regions.resize(1);
                     regions[0].chrom = parts[0];
                     regions[0].start = (start - pad > 0) ? start - pad : 1;
                     regions[0].end = end + pad;
-                    regions[0].markerPos = start;
-                    regions[0].markerPosEnd = end;
+                    regions[0].markers = {{start, end}};
                 }
             }
         } else {
@@ -322,8 +319,6 @@ namespace Utils {
                     N.chrom = parts[i];
                     N.start = start;
                     N.end = end;
-                    N.markerPos = -1;
-                    N.markerPosEnd = -1;
                     regions.push_back(N);
                     i += 3;
                 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <string>
+#include <utility>
 #include <vector>
 #include "ankerl_unordered_dense.h"
 #include "export_definitions.h"
@@ -89,6 +90,7 @@ namespace Utils {
         std::string chrom{};
         int start{1}, end{20000};
         int markerPos{-1}, markerPosEnd{-1};
+        std::vector<std::pair<int,int>> extraMarkers;
         int chromLen{0};
         int refSeqLen{0};
         int regionLen{0};

--- a/src/utils.h
+++ b/src/utils.h
@@ -89,8 +89,7 @@ namespace Utils {
     public:
         std::string chrom{};
         int start{1}, end{20000};
-        int markerPos{-1}, markerPosEnd{-1};
-        std::vector<std::pair<int,int>> extraMarkers;
+        std::vector<std::pair<int,int>> markers;
         int chromLen{0};
         int refSeqLen{0};
         int regionLen{0};


### PR DESCRIPTION
## Summary

While building an web application using gw to visualise alignments I wanted to visualise splice variants and place a marker at each end of the splice junction in the same region. I can see gw only allowed one marker per region (for the vcf file variant markers).

### What have I done?
- given the region class an extra attribute (extraMarkers) - a vector of 2 int positions 
- altered the drawing script so both markers can be visualised on the same region
- added a plot command to add and clear markers in regions

### Usage
- This is to add a command line method of working with markers via the command line (not just by vcfs)
- I aim to add this function to gwplot (and have already added it to a custom api)