### PR TITLE
Set vertical scroll

### DIFF
--- a/src/plot_controls.cpp
+++ b/src/plot_controls.cpp
@@ -68,6 +68,32 @@ namespace Manager {
         }
     }
 
+    // Set an absolute vertical read-scroll offset across all collections and
+    // re-run the layout. Mirrors the Ctrl+[ / Ctrl+] handling in registerKey
+    // (see the reset block below), but takes an absolute value rather than a step.
+    void GwPlot::setVScroll(int value) {
+        if (collections.empty() || regions.empty()) {
+            return;
+        }
+        int v = std::max(0, value);
+        for (auto & cl : collections) {
+            cl.vScroll = v;
+        }
+        redraw = true;
+        processed = true;
+        imageCacheQueue.clear();
+        for (auto & cl : collections) {
+            cl.resetDrawState();
+            cl.levelsStart.clear();
+            cl.levelsEnd.clear();
+            cl.linked.clear();
+            Utils::SortType srt_option = regions[regionSelection].getSortOption();
+            for (auto &itm: cl.readQueue) { itm.y = -1; }
+            int maxY = Segs::findY(cl, cl.readQueue, opts.link_op, opts, false, srt_option);
+            samMaxY = (maxY > samMaxY || opts.tlen_yscale) ? maxY : samMaxY;
+        }
+    }
+
     // keeps track of input commands. returning GLFW_KEY_UNKNOWN stops further processing of key codes
     int GwPlot::registerKey(GLFWwindow* wind, int key, int scancode, int action, int mods) {
         std::ostream& out = (terminalOutput) ? std::cout : outStr;

--- a/src/plot_manager.h
+++ b/src/plot_manager.h
@@ -256,6 +256,7 @@ namespace Manager {
         bool commandProcessed();
         void prepareSelectedRegion();
         void addAlignmentToSelectedRegion();
+        void setVScroll(int value);  // set absolute vertical read-scroll offset and re-layout
 
         // Draw functions
         void drawBackground();


### PR DESCRIPTION
### Summary

This pull request is to add a function to set the vertical scroll on a gw instance.

This is primarily used when gw is being controlled by a gwplot like cython wrapper, and allows easy implementation of a scrollbar when GW is controlled via the web.

### Details
Sets the absolute vertical scroll offset of the alignment track
- clamps vertical scroll (vScroll) at 0
- clears frame/image cache and requests a redraw
- identifies the max scroll (samMaxY) and clamps it at the max tlen-y


